### PR TITLE
bugfix: cast source dataset samples to float32

### DIFF
--- a/src/mlcast/data/source_data_datasets.py
+++ b/src/mlcast/data/source_data_datasets.py
@@ -261,7 +261,9 @@ class SourceDataDatasetBase(Dataset, ABC):
         if self.return_mask:
             target_mask_t = torch.from_numpy((~np.isnan(data[self.input_steps :])).astype(np.float32))
 
-        data = np.nan_to_num(data, nan=-1.0)
+        # source data may be float64, but the model and the rest of the
+        # training pipeline operate in float32.
+        data = np.nan_to_num(data, nan=-1.0).astype(np.float32)
         data_t = torch.from_numpy(data)
 
         input_t = data_t[: self.input_steps]
@@ -413,7 +415,9 @@ class SourceDataPrecomputedSamplingDataset(SourceDataDatasetBase):
             norm_func = NORMALIZATION_REGISTRY[std_name]
             channels.append(norm_func(da_var.values))
 
-        data = np.swapaxes(np.stack(channels, axis=0), 0, 1)
+        # swapaxes returns a view; make it contiguous and float32 before
+        # handing it to _build_sample()/torch.from_numpy().
+        data = np.ascontiguousarray(np.swapaxes(np.stack(channels, axis=0), 0, 1), dtype=np.float32)
         return self._build_sample(data)
 
 
@@ -540,5 +544,7 @@ class SourceDataRandomSamplingDataset(SourceDataDatasetBase):
             norm_func = NORMALIZATION_REGISTRY[std_name]
             channels.append(norm_func(da_var.values))
 
-        data = np.swapaxes(np.stack(channels, axis=0), 0, 1)
+        # swapaxes returns a view; make it contiguous and float32 before
+        # handing it to _build_sample()/torch.from_numpy().
+        data = np.ascontiguousarray(np.swapaxes(np.stack(channels, axis=0), 0, 1), dtype=np.float32)
         return self._build_sample(data)

--- a/tests/data/test_source_data_datasets.py
+++ b/tests/data/test_source_data_datasets.py
@@ -113,6 +113,9 @@ def test_random_sampling_dataset(fp_test_dataset: Path) -> None:
     assert input_t.shape == (input_steps, 1, 32, 32)
     assert target_t.shape == (forecast_steps, 1, 32, 32)
     assert target_mask_t.shape == (forecast_steps, 1, 32, 32)
+    assert input_t.dtype == torch.float32
+    assert target_t.dtype == torch.float32
+    assert target_mask_t.dtype == torch.float32
 
 
 def test_random_sampling_dataset_time_slice(fp_test_dataset: Path) -> None:


### PR DESCRIPTION
Some datasets might be stored in float64 (e.g. the DMI radar dataset is). This PR introduces casting to float32