### PR TITLE
fix: scope data gitignore pattern to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ dist/
 .venv/
 logs/
 .pytest_cache/
-data/
+/data/
 mlruns/
 MagicMock/


### PR DESCRIPTION
- change the broad data/ ignore rule to /data/ so src/mlcast/data is no longer matched accidentally

- avoid needing force-adds for tracked source files under the mlcast.data package