### PR TITLE
Feat: dynamic versions, precommit and release ci workflows

### DIFF
--- a/.github/workflows/ci-pypi-deploy.yml
+++ b/.github/workflows/ci-pypi-deploy.yml
@@ -1,0 +1,52 @@
+name: package-release
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: build package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - run: uv build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: package-dist
+          path: dist/*
+
+  publish:
+    name: publish package to PyPI
+    needs: build
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: package-dist
+          path: dist
+
+      # Requires PyPI Trusted Publishing to be configured for this GitHub
+      # repository/workflow/environment on pypi.org. The `id-token: write`
+      # permission above lets this action request an OIDC token, in place of a
+      # PYPI_TOKEN repository secret.
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,22 @@
+name: linting
+
+on:
+  # Run on every pushed branch.
+  push:
+  # Run on every pull request update.
+  pull_request:
+
+jobs:
+  linting:
+    name: "pre-commit hooks"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      # Run pre-commit through uv so CI uses the same project-managed environment
+      # as local development, including local hooks that invoke `uv run ...`.
+      - run: uv run pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+### CI actions are pinned to immutable commit hashes, not mutable tags, to reduce supply-chain risk and help prevent LLM-based CI attacks. See https://github.com/lirantal/pypi-security-best-practices#13-secure-your-cicd-release-pipeline.
 name: linting
 
 on:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
     name: "pre-commit hooks"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: package-dist
           path: dist

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,3 +1,4 @@
+### CI actions are pinned to immutable commit hashes, not mutable tags, to reduce supply-chain risk and help prevent LLM-based CI attacks. See https://github.com/lirantal/pypi-security-best-practices#13-secure-your-cicd-release-pipeline.
 name: publish to pypi
 
 on:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,48 @@
+name: publish to pypi
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: build package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - run: uv build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: package-dist
+          path: dist/*
+
+  publish:
+    name: publish package to PyPI
+    needs: build
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: package-dist
+          path: dist
+
+      # Requires PyPI Trusted Publishing to be configured for this GitHub
+      # repository/workflow/environment on pypi.org. The `id-token: write`
+      # permission above lets this action request an OIDC token, in place of a
+      # PYPI_TOKEN repository secret.
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - run: uv build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package-dist
           path: dist/*

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -11,7 +11,7 @@ jobs:
     name: build package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -46,4 +46,4 @@ jobs:
       # repository/workflow/environment on pypi.org. The `id-token: write`
       # permission above lets this action request an OIDC token, in place of a
       # PYPI_TOKEN repository secret.
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # 1.14.0

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,14 +1,9 @@
-name: package-release
+name: publish to testpypi
 
 on:
-  workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main
-  release:
-    types:
-      - published
 
 jobs:
   build:
@@ -32,11 +27,10 @@ jobs:
           path: dist/*
 
   publish:
-    name: publish package to PyPI
+    name: publish package to TestPyPI
     needs: build
-    if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: testpypi
     permissions:
       id-token: write
     steps:
@@ -45,8 +39,10 @@ jobs:
           name: package-dist
           path: dist
 
-      # Requires PyPI Trusted Publishing to be configured for this GitHub
-      # repository/workflow/environment on pypi.org. The `id-token: write`
+      # Requires TestPyPI Trusted Publishing to be configured for this GitHub
+      # repository/workflow/environment on test.pypi.org. The `id-token: write`
       # permission above lets this action request an OIDC token, in place of a
       # PYPI_TOKEN repository secret.
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,3 +1,4 @@
+### CI actions are pinned to immutable commit hashes, not mutable tags, to reduce supply-chain risk and help prevent LLM-based CI attacks. See https://github.com/lirantal/pypi-security-best-practices#13-secure-your-cicd-release-pipeline.
 name: publish to testpypi
 
 on:

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -43,6 +43,6 @@ jobs:
       # repository/workflow/environment on test.pypi.org. The `id-token: write`
       # permission above lets this action request an OIDC token, in place of a
       # PYPI_TOKEN repository secret.
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # 1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -10,7 +10,7 @@ jobs:
     name: build package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -21,7 +21,7 @@ jobs:
 
       - run: uv build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package-dist
           path: dist/*

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: package-dist
           path: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ maintainers = [
 authors = [
   { name = "Gabriele Franch", email = "franch@fbk.eu" },
   { name = "Leif Denby", email = "lcd@dmi.dk" },
+  { name = "Oscar Dewasmes", email = "oscar.dewasmes@meteo.fr" },
 ]
 requires-python = ">=3.11"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
 build-backend = "hatchling.build"
 
-requires = [ "hatchling" ]
+requires = [ "hatch-vcs", "hatchling" ]
 
 [project]
 name = "mlcast"
-version = "0.0.1a5"
 description = "Machine learning weather nowcasting library"
 readme = "README.md"
 keywords = [ "machine-learning", "meteorology", "nowcasting", "precipitation", "pytorch", "radar", "weather" ]
@@ -30,6 +29,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Atmospheric Science",
 ]
 
+dynamic = [ "version" ]
 dependencies = [
   "absl-py>=2.4",
   "beartype>=0.18",
@@ -87,6 +87,9 @@ dev = [
   "pytest>=9.0.3",
 ]
 mlflow = [  ]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.ruff]
 line-length = 120

--- a/src/mlcast/__init__.py
+++ b/src/mlcast/__init__.py
@@ -1,3 +1,8 @@
 """MLCast - Machine learning weather nowcasting library."""
 
-__version__ = "0.0.1a5"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("mlcast")
+except PackageNotFoundError:
+    __version__ = "0+unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -2232,7 +2232,6 @@ wheels = [
 
 [[package]]
 name = "mlcast"
-version = "0.0.1a5"
 source = { editable = "." }
 dependencies = [
     { name = "absl-py" },


### PR DESCRIPTION
In preparation of `v0.1.0` of `mlcast` this PR adds the following:

- replaces static versions (stored in `pyproject.toml`) with dynamic versions derived from `git` tags. This means makes it easier to create releases and also makes it clear when people have made local modifications relative to tagged versions (since the dynamic version will the be something like `0.1.1.devN+g<hash>` (I have tagged commit `b3f086b` as `v0.0.1a4` as that commit was released with that version on pipy.org, to ensure that no one else took the `mlcast` package name)
- add CI action for running `pre-commit` on PRs and pushes
- add CI action for package build and upload of releases (on github) to pypi.org based on pypi trusted publishing where a repo is registered on pypi.org as being permitted to publish to a specific project on pypi.org
- add CI action that builds the package on every push to `main` and uploads to test.pypi.org testing server. This ensure that the build and upload is working, and we have a collection of the intermediate package builds (for as long as test.pypi.org keeps them). This might be redundant, but I haven't used the "trusted publishing" approach before (I usually go with a saved token in github secrets, but the trusted publishing seems better since this trusted token in a secret is then no longer needed)