### PR TITLE
Fix ConvGRU ensemble training nora

### DIFF
--- a/src/mlcast/data/source_data_datasets.py
+++ b/src/mlcast/data/source_data_datasets.py
@@ -396,8 +396,19 @@ class SourceDataPrecomputedSamplingDataset(SourceDataDatasetBase):
             self.coords = self.coords[(self.coords["t"] >= t_start) & (self.coords["t"] < t_stop)].reset_index(
                 drop=True
             )
+            # adjust the range as the index was reset in the previous line
+            self.coords["t"] = self.coords["t"] - t_start
 
         self.dt = time_depth
+        
+
+        # Open and check max size of sliced zarr
+        with xr.open_zarr(zarr_path, **(storage_options or {})) as raw_ds:
+            max_zarr_steps = (t_stop - t_start) if self._time_index_slice is not None else raw_ds.sizes[self.t_dim]
+
+        # remove any samples that reach into the validation data
+        self.coords = self.coords[self.coords["t"] + self.dt <= max_zarr_steps].reset_index(drop=True)
+
 
         if self.steps > self.dt:
             print(f"Warning: requested steps ({self.steps}) > sampled time window ({self.dt})")

--- a/src/mlcast/losses.py
+++ b/src/mlcast/losses.py
@@ -74,11 +74,18 @@ class MaskedLoss(LossWithReduction):
         loss : torch.Tensor
             Scalar loss value.
         """
-        elementwise_loss = self.elementwise_loss(preds, target)
-        masked_loss = elementwise_loss * mask
 
-        broadcast_factor = elementwise_loss.numel() // mask.numel()
-        valid_pixels = mask.sum() * broadcast_factor
+        elementwise_loss = self.elementwise_loss(preds, target)
+        
+        # if loss compressed along time dimension, compress the mask in the same way
+        if mask.shape[1] != elementwise_loss.shape[1] and elementwise_loss.shape[1] == 1:
+            mask = mask.mean(dim=1, keepdim=True)
+
+        masked_loss = elementwise_loss * mask
+ 
+        # mask now corresponds to the number of valid pixels
+        valid_pixels = mask.sum()
+
         if valid_pixels > 0:
             if self.reduction == "mean":
                 return masked_loss.sum() / valid_pixels
@@ -87,6 +94,7 @@ class MaskedLoss(LossWithReduction):
             else:
                 return masked_loss
         else:
+            
             logger.warning(
                 "Encountered a training batch with all NaNs (completely masked). "
                 "The loss and gradients for this batch will be exactly zero."


### PR DESCRIPTION
Minor fixes required to get it to run on my system at DWD:

1. Indexing was wrong for validation data. Example: If the entire dataset had time steps 0-1400 and 1000 to 1200 was selected for validation, the code would look for 1000 to 1200 in the sliced zarr, but the index was reset, so instead it should be 0-200.
2. I got crashes for training samples that started within the training dataset, but reached into the validation dataset. These are now removed.
3. During the loss calculation, losses are collapsed over the time dimension and a broadcasting factor was used to calculate the number of valid pixels. That factor was always 0 for me turning all losses into zero. (Maybe it was due to dividing two large numbers, I don't remember for sure anymore...). Fixed by collapsing the mask and using it to calculate the number of valid pixels.


After these fixes, ConvGRU ensemble training works well for me. I just had to turn off pin memory and reduce the batch size due to memory constraints. Maybe I can fix that on my side.